### PR TITLE
chore: add deepin1 suffix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+malcontent (0.11.1-3deepin1) unstable; urgency=medium
+
+  * Add deepin1 suffix
+
+ -- Wang Zichong <wangzichong@deepin.org>  Fri, 17 May 2024 16:28:00 +0800
+
 malcontent (0.11.1-3) unstable; urgency=medium
 
   * Team upload


### PR DESCRIPTION
目的是目前因 appstream 更新而需要此包 rebuild，版本名称需要遵循目前的版本规范，所以需要加 deepin1 后缀。